### PR TITLE
Add Numbstrict documentation with usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Numbstrict
+
+Numbstrict is a small parser for a relaxed data notation.
+
+- [Numbstrict Documentation](docs/Numbstrict%20Documentation.md)
+- [Makaron Documentation](docs/Makaron%20Documentation.md)
+

--- a/docs/Makaron Documentation.md
+++ b/docs/Makaron Documentation.md
@@ -3,6 +3,8 @@ Makaron
 
 _Makaron_ is a macro expansion language designed to simplify and streamline your code. Makaron allows you to define and use macros for text substitution in your code, making it more readable and maintainable. The language includes features for defining string macros with [`@define`](#define), parametric macros with [`@begin`](#begin) and `@end`, and conditional output macros with [`@if`](#if). These macros can be [invoked](#invocation) by prefixing the macro name with "@" in the text.
 
+See [Numbstrict Documentation](Numbstrict%20Documentation.md) for details on the Numbstrict data format.
+
 Table of Contents
 -----------------
 
@@ -274,3 +276,4 @@ Example:
 	@>
 
  Notice that macro expansion is still performed inside _raw values_. To include _at characters_, you need to use `@@` just like everywhere else.
+

--- a/docs/Numbstrict Documentation.md
+++ b/docs/Numbstrict Documentation.md
@@ -1,0 +1,54 @@
+Numbstrict Documentation
+=========================
+
+Numbstrict is a minimal data format and parser for structured values.
+
+Supported value types
+---------------------
+
+Numbstrict values can be parsed into these types:
+
+- **Structs** – key/value pairs wrapped in `{}` with a colon after each key.
+- **Arrays** – comma or newline separated values inside `{}`.
+- **Text** – quoted with `"` or `'` or left unquoted when no special characters are present.
+- **Numbers** – integers, unsigned integers and real numbers with optional exponent.
+- **Booleans** – `true` and `false`.
+
+Parsing rules and error handling
+--------------------------------
+
+- Commas and/or newlines separate list items in arrays and structs. Trailing commas are only allowed in arrays.
+- A colon must follow struct keys on the same line. `{ : }` denotes an empty struct.
+- Single line `//` and multi-line `/* */` comments may appear between values.
+- Escape sequences in strings support `\n`, `\r`, `\t`, `\\`, `\x`, `\u` and `\U` forms.
+- `Element::to<T>()` and `Parser::parse()` throw `ParsingError` when the source is invalid. `UndefinedElementError` is thrown when accessing a non-existent value.
+- `Parser::tryToParse()` returns `false` on failure and leaves the read position at the point of error so the caller can recover or report diagnostics.
+
+Examples
+--------
+
+### Element
+
+```cpp
+using namespace Numbstrict;
+
+Element src("{ x: 1, nums: { 10, 20 } }");
+Struct s = src.to<Struct>();
+int x = s["x"].to<int>();
+Array numbers = s["nums"].to<Array>();
+```
+
+### Parser
+
+```cpp
+using namespace Numbstrict;
+
+Element src("{ x: 1, invalid }");
+Parser p(src);
+Struct s;
+size_t offset;
+if(!p.tryToParse(s, offset)) {
+// handle error at offset
+}
+```
+


### PR DESCRIPTION
## Summary
- Documented supported value types, parsing rules, and error handling.
- Added Element and Parser code examples.
- Linked the new doc from README and Makaron docs.

## Testing
- `timeout 180 bash build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6890ba59b19083328605b050cb587373