### PR TITLE
Add Numbstrict and Makaron fuzz build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,36 @@ On Windows:
 build.cmd
 ```
 
+## Fuzzing
+
+The repository includes libFuzzer harnesses for the Numbstrict and Makaron parsers. The helper scripts compile the fuzz targets with address and fuzzer sanitizers.
+
+### Numbstrict
+
+```bash
+bash tools/build_numbstrict_fuzz.sh
+```
+
+The resulting binary is placed in `output/NumbstrictFuzz` and can be run with a directory containing seed inputs:
+
+```bash
+./output/NumbstrictFuzz corpus/
+```
+
+### Makaron
+
+```bash
+bash tools/build_makaron_fuzz.sh
+```
+
+The resulting binary is placed in `output/MakaronFuzz` and accepts a corpus directory like the Numbstrict target.
+
+On macOS the default clang from Xcode does not ship the libFuzzer runtime. Install the `llvm` package via Homebrew and invoke the scripts with that compiler:
+
+```bash
+CPP_COMPILER=$(brew --prefix llvm)/bin/clang++ bash tools/build_numbstrict_fuzz.sh
+```
+
 ## Usage
 
 ```cpp

--- a/tests/MakaronFuzz.cpp
+++ b/tests/MakaronFuzz.cpp
@@ -1,0 +1,15 @@
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include "../src/Makaron.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+	try {
+		Makaron::String src(reinterpret_cast<const char*>(data), size);
+		Makaron::Context ctx;
+		Makaron::String processed;
+		ctx.process(Makaron::Span(src, L"<fuzz>"), processed, nullptr);
+	} catch (const Makaron::Exception&) {
+	}
+	return 0;
+}

--- a/tests/NumbstrictFuzz.cpp
+++ b/tests/NumbstrictFuzz.cpp
@@ -1,0 +1,14 @@
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include "../src/Numbstrict.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+	const std::string input(reinterpret_cast<const char*>(data), size);
+	try {
+		Numbstrict::Struct s = Numbstrict::parseStruct(input, "fuzz");
+		Numbstrict::compose(s);
+	} catch (const Numbstrict::Exception&) {
+	}
+	return 0;
+}

--- a/tools/build_makaron_fuzz.cmd
+++ b/tools/build_makaron_fuzz.cmd
@@ -1,0 +1,8 @@
+@ECHO OFF
+CD /D "%~dp0\.."
+IF NOT EXIST output MKDIR output
+SET CPP_OPTIONS=/I src /fsanitize:fuzzer,address
+CALL tools\BuildCpp.cmd beta x64 output\MakaronFuzz.exe tests\MakaronFuzz.cpp src\Makaron.cpp || GOTO error
+EXIT /b 0
+:error
+EXIT /b %ERRORLEVEL%

--- a/tools/build_makaron_fuzz.sh
+++ b/tools/build_makaron_fuzz.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"/..
+mkdir -p ./output
+CPP_OPTIONS="-I ./src -fsanitize=fuzzer,address" \
+  bash ./tools/BuildCpp.sh beta native output/MakaronFuzz \
+    tests/MakaronFuzz.cpp src/Makaron.cpp

--- a/tools/build_numbstrict_fuzz.cmd
+++ b/tools/build_numbstrict_fuzz.cmd
@@ -1,0 +1,8 @@
+@ECHO OFF
+CD /D "%~dp0\.."
+IF NOT EXIST output MKDIR output
+SET CPP_OPTIONS=/fsanitize:fuzzer,address
+CALL tools\BuildCpp.cmd beta x64 output\NumbstrictFuzz.exe tests\NumbstrictFuzz.cpp src\Numbstrict.cpp || GOTO error
+EXIT /b 0
+:error
+EXIT /b %ERRORLEVEL%

--- a/tools/build_numbstrict_fuzz.sh
+++ b/tools/build_numbstrict_fuzz.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"/..
+mkdir -p ./output
+CPP_OPTIONS="-fsanitize=fuzzer,address" \
+  bash ./tools/BuildCpp.sh beta native output/NumbstrictFuzz \
+    tests/NumbstrictFuzz.cpp src/Numbstrict.cpp


### PR DESCRIPTION
## Summary
- add minimal libFuzzer harnesses for Numbstrict and Makaron
- add cross-platform scripts to build each fuzz target
- document fuzz build and run instructions in README

## Testing
- `CPP_COMPILER=clang++ bash tools/build_numbstrict_fuzz.sh`
- `CPP_COMPILER=clang++ bash tools/build_makaron_fuzz.sh`
- `timeout 180 bash build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6890c7812a308332a5c13e99cf7b935c