### PR TITLE
Build scripts compile MakaronCmd utility

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -7,9 +7,14 @@ FOR %%t IN (beta release) DO (
 	SET "outDir=output\%%t"
 	IF NOT EXIST "%%outDir%%" MKDIR "%%outDir%%"
 	SET "CPP_OPTIONS=/std:c++14"
-	CALL tools\BuildCpp.cmd %%t native "%%outDir%%\smoke.exe" -I src tests\smoke.cpp src\Numbstrict.cpp src\Makaron.cpp || GOTO error
+	CALL tools\BuildCpp.cmd %%t native "%%outDir%%\smoke.exe" -I src ^
+		tests\smoke.cpp src\Numbstrict.cpp src\Makaron.cpp || GOTO error
 	SET "CPP_OPTIONS="
 	"%%outDir%%\smoke.exe" >NUL || GOTO error
+	SET "CPP_OPTIONS=/std:c++14"
+	CALL tools\BuildCpp.cmd %%t native "%%outDir%%\MakaronCmd.exe" -I src ^
+		tools\MakaronCmd.cpp src\Makaron.cpp || GOTO error
+	SET "CPP_OPTIONS="
 )
 ECHO Build and tests completed
 EXIT /b 0

--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,11 @@ cd "$(dirname "$0")"
 for target in beta release; do
 	out_dir="output/$target"
 	mkdir -p "$out_dir"
-	CPP_OPTIONS="-std=c++11" bash tools/BuildCpp.sh "$target" native "$out_dir/smoke" -I src tests/smoke.cpp src/Numbstrict.cpp src/Makaron.cpp
+	CPP_OPTIONS="-std=c++11" bash tools/BuildCpp.sh "$target" native "$out_dir/smoke" \
+		-I src tests/smoke.cpp src/Numbstrict.cpp src/Makaron.cpp
 	"$out_dir/smoke" > /dev/null
+	CPP_OPTIONS="-std=c++11" bash tools/BuildCpp.sh "$target" native "$out_dir/MakaronCmd" \
+		-I src tools/MakaronCmd.cpp src/Makaron.cpp
 done
 
 echo "Build and tests completed"


### PR DESCRIPTION
## Summary
- Extend `build.sh` and `build.cmd` to compile the MakaronCmd command-line utility alongside smoke tests.
- Adapt `MakaronCmd.cpp` for cross-platform builds with proper wide-string handling and C string helpers.
- Normalize indentation in `MakaronCmd.cpp` for consistent style.

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68920a23ca708332a77252180cab20c6