### PR TITLE
Standardize scripts and add Windows counterparts

### DIFF
--- a/docs/updateDocs.cmd
+++ b/docs/updateDocs.cmd
@@ -1,0 +1,7 @@
+@ECHO OFF
+SETLOCAL
+CD /D "%~dp0"
+pandoc -s -o "Makaron Documentation.html" --metadata title="Makaron Documentation" --include-in-header pandoc.css "Makaron Documentation.md" || GOTO error
+EXIT /b 0
+:error
+EXIT /b %ERRORLEVEL%

--- a/docs/updateDocs.sh
+++ b/docs/updateDocs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -o pipefail -u
 cd "$(dirname "$0")"
 pandoc -s -o "Makaron Documentation.html" --metadata title="Makaron Documentation" --include-in-header pandoc.css "Makaron Documentation.md"

--- a/tools/buildMakaronCmd.cmd
+++ b/tools/buildMakaronCmd.cmd
@@ -1,0 +1,7 @@
+@ECHO OFF
+SETLOCAL
+CD /D "%~dp0"
+CALL BuildCpp.cmd release x64 makaron.exe -I ..\src MakaronCmd.cpp ..\src\Makaron.cpp || GOTO error
+EXIT /b 0
+:error
+EXIT /b %ERRORLEVEL%

--- a/tools/buildMakaronCmd.command
+++ b/tools/buildMakaronCmd.command
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-cd "$(dirname "$0")"
-chmod +x ./BuildCpp.sh
-./BuildCpp.sh release 64 ./makaron -I ../src/ ./MakaronCmd.cpp ../src/Makaron.cpp

--- a/tools/buildMakaronCmd.sh
+++ b/tools/buildMakaronCmd.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"
+bash BuildCpp.sh release x64 makaron -I ../src/ MakaronCmd.cpp ../src/Makaron.cpp


### PR DESCRIPTION
## Summary
- Use `/usr/bin/env bash` with strict options and change to the script directory in `docs/updateDocs.sh` and `tools/buildMakaronCmd.sh`
- Rename `buildMakaronCmd.command` to `.sh`
- Add Windows `.cmd` equivalents for updating docs and building Makaron

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a9b48c9f6483329d74e2eceedfbb67