### PR TITLE
Add test ensuring realToString outputs shortest decimal strings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,9 @@ for target in beta release; do
 	CPP_OPTIONS="-std=c++11" bash tools/BuildCpp.sh "$target" native "$out_dir/doubleFloatToString" \
 		-I src tests/doubleFloatToString.cpp src/Numbstrict.cpp src/Makaron.cpp
 	"$out_dir/doubleFloatToString" > /dev/null
+	CPP_OPTIONS="-std=c++11" bash tools/BuildCpp.sh "$target" native "$out_dir/realToStringShortest" \
+		-I src tests/realToStringShortest.cpp src/Numbstrict.cpp src/Makaron.cpp
+	"$out_dir/realToStringShortest" > /dev/null
 	CPP_OPTIONS="-std=c++11" bash tools/BuildCpp.sh "$target" native "$out_dir/MakaronCmd" \
 		-I src tools/MakaronCmd.cpp src/Makaron.cpp
 done

--- a/tests/realToStringShortest.cpp
+++ b/tests/realToStringShortest.cpp
@@ -1,0 +1,98 @@
+#include "../src/Numbstrict.h"
+#include <cassert>
+#include <random>
+#include <string>
+#include <cstring>
+#include <cmath>
+#include <cstdint>
+#include <type_traits>
+
+using Numbstrict::String;
+
+template<typename T> static String toString(T value);
+template<> String toString<float>(float value) { return Numbstrict::floatToString(value); }
+template<> String toString<double>(double value) { return Numbstrict::doubleToString(value); }
+
+template<typename T> static T fromString(const String& s);
+template<> float fromString<float>(const String& s) { return Numbstrict::stringToFloat(s); }
+template<> double fromString<double>(const String& s) { return Numbstrict::stringToDouble(s); }
+
+template<typename T> static bool bitsEqual(T a, T b);
+template<> bool bitsEqual<float>(float a, float b) {
+	uint32_t ua, ub;
+	std::memcpy(&ua, &a, 4);
+	std::memcpy(&ub, &b, 4);
+	return ua == ub;
+}
+template<> bool bitsEqual<double>(double a, double b) {
+	uint64_t ua, ub;
+	std::memcpy(&ua, &a, 8);
+	std::memcpy(&ub, &b, 8);
+	return ua == ub;
+}
+
+template<typename T> static bool isShortest(const String& s, T value) {
+	// split into mantissa + exponent (support 'e' or 'E')
+	size_t expPos = s.find('e');
+	if (expPos == String::npos) expPos = s.find('E');
+	const String exponent = (expPos == String::npos ? String() : s.substr(expPos));
+	String mantissa = (expPos == String::npos ? s : s.substr(0, expPos));
+
+	const size_t signOffset = (mantissa[0] == '-' || mantissa[0] == '+' ? 1 : 0);
+
+	// 1) Try removing a trailing ".0" entirely (e.g., "123.0" -> "123")
+	if (mantissa.size() >= signOffset + 2 && mantissa.back() == '0' && mantissa[mantissa.size() - 2] == '.') {
+	String shortened = mantissa.substr(0, mantissa.size() - 2) + exponent;
+	T r = fromString<T>(shortened);
+	if (bitsEqual<T>(r, value)) return false;
+}
+
+	// 2) Your original digit-trim loop, but if a '.' is left dangling, also try removing it
+	String work = mantissa;
+	while (work.size() > signOffset + 1) {
+	// drop last char (a digit)
+	work.erase(work.size() - 1);
+
+	// if we ended on '.', try without the dot as well
+	if (!work.empty() && work.back() == '.') {
+	String shortened = work.substr(0, work.size() - 1) + exponent;
+	T r = fromString<T>(shortened);
+	if (bitsEqual<T>(r, value)) return false;
+	// stop further trimming when dot reached (no more fractional digits to drop safely here)
+	break;
+} else {
+	String shortened = work + exponent;
+	T r = fromString<T>(shortened);
+	if (bitsEqual<T>(r, value)) return false;
+}
+}
+
+	return true;
+}
+
+template<typename T, typename Rng> static void testType(Rng& rng) {
+	for (int i = 0; i != 10000; ++i) {
+	typename std::conditional<sizeof(T) == 4, uint32_t, uint64_t>::type bits = rng();
+	T value;
+	std::memcpy(&value, &bits, sizeof value);
+	if (!std::isfinite(value)) {
+	continue;
+}
+	const String s = toString<T>(value);
+	const T round = fromString<T>(s);
+	assert(bitsEqual<T>(round, value));
+	static_cast<void>(round);
+	if (s.find(".0") != String::npos && s.find('e') == String::npos && s.find('E') == String::npos) {
+	continue;
+}
+	assert(isShortest<T>(s, value));
+}
+}
+
+int main() {
+	std::mt19937_64 rng(1234567);
+	testType<double>(rng);
+	testType<float>(rng);
+	return 0;
+}
+


### PR DESCRIPTION
## Summary
- add bitwise comparison helpers and tightened shortest-string check for `realToString`
- run randomized round-trip test over 10k float and double samples while skipping mandated `.0` cases

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68be9992107c83329c13ff994ac28f74