### PR TITLE
Refine shortest real string check

### DIFF
--- a/tests/realToStringShortest.cpp
+++ b/tests/realToStringShortest.cpp
@@ -32,69 +32,79 @@ template<> bool bitsEqual<double>(double a, double b) {
 }
 
 template<typename T> static bool isShortest(const String& s, T value) {
-	// split into mantissa + exponent (support 'e' or 'E')
 	size_t expPos = s.find('e');
 	if (expPos == String::npos) expPos = s.find('E');
 	const String exponent = (expPos == String::npos ? String() : s.substr(expPos));
 	String mantissa = (expPos == String::npos ? s : s.substr(0, expPos));
-	size_t dotPos = mantissa.find('.');
+
+	if (mantissa.empty()) return true;
 
 	const size_t signOffset = (mantissa[0] == '-' || mantissa[0] == '+' ? 1 : 0);
+	if (mantissa.size() < signOffset + 1) return true;
 
-	// 1) Try removing a trailing ".0" entirely (e.g., "123.0" -> "123")
-	if (dotPos != String::npos && mantissa.back() == '0' && mantissa[mantissa.size() - 2] == '.') {
-		if (expPos == String::npos || mantissa.size() - dotPos > 2) {
+	// If mantissa ends with '.', try dropping it (e.g., "123." -> "123")
+	if (mantissa.size() > signOffset + 1 && mantissa.back() == '.') {
+		String shortened = mantissa.substr(0, mantissa.size() - 1) + exponent;
+		T r = fromString<T>(shortened);
+		if (bitsEqual<T>(r, value)) return false;
+	}
+
+	// Try removing a trailing ".0" (e.g., "123.0" -> "123"), but keep 1 frac digit in E-form
+	size_t dotPos0 = mantissa.find('.');
+	if (dotPos0 != String::npos && mantissa.size() >= 2 && mantissa.back() == '0' && mantissa[mantissa.size() - 2] == '.') {
+		if (expPos == String::npos || (mantissa.size() - dotPos0 > 2)) {
 			String shortened = mantissa.substr(0, mantissa.size() - 2) + exponent;
 			T r = fromString<T>(shortened);
 			if (bitsEqual<T>(r, value)) return false;
 		}
 	}
 
-	// 2) Trim digits but keep at least one fractional digit when exponent is present
+	// Trim last coefficient digit while preserving:
+	// - round-trip equality
+	// - at least 1 fractional digit when exponent is present
 	String work = mantissa;
 	while (work.size() > signOffset + 1) {
+		// recompute dot every iteration (the original code used a stale position)
+		size_t dotPos = work.find('.');
+
+		// In E-form, keep at least one fractional digit (i.e., don't let "x.y" shrink to "x.")
 		if (expPos != String::npos && dotPos != String::npos) {
-			if (work.size() - dotPos <= 2) {
-				break;
-			}
+			size_t fracLen = work.size() - dotPos - 1; // digits after '.'
+			if (fracLen <= 1) break;
 		}
-		// drop last char (a digit)
+
+		// drop last char
 		work.erase(work.size() - 1);
 
-		// if we ended on '.', try without the dot as well
+		// if we ended on '.', try without the dot as well (only allowed in fixed form)
 		if (!work.empty() && work.back() == '.') {
 			if (expPos == String::npos) {
 				String shortened = work.substr(0, work.size() - 1) + exponent;
 				T r = fromString<T>(shortened);
 				if (bitsEqual<T>(r, value)) return false;
 			}
-			// stop further trimming when dot reached (no more fractional digits to drop safely here)
-			break;
+			break; // stop at the dot
 		} else {
 			String shortened = work + exponent;
 			T r = fromString<T>(shortened);
 			if (bitsEqual<T>(r, value)) return false;
 		}
 	}
-
 	return true;
 }
 
 template<typename T, typename Rng> static void testType(Rng& rng) {
-	for (int i = 0; i != 1000000; ++i) {
+	for (int i = 0; i != 10000000; ++i) {
 		typename std::conditional<sizeof(T) == 4, uint32_t, uint64_t>::type bits = rng();
 		T value;
 		std::memcpy(&value, &bits, sizeof value);
-		if (!std::isfinite(value)) {
-			continue;
-		}
+		if (!std::isfinite(value)) continue;
+
 		const String s = toString<T>(value);
 		const T round = fromString<T>(s);
 		assert(bitsEqual<T>(round, value));
 		static_cast<void>(round);
-		if (s.find(".0") != String::npos && s.find('e') == String::npos && s.find('E') == String::npos) {
-			continue;
-		}
+
 		assert(isShortest<T>(s, value));
 	}
 }


### PR DESCRIPTION
## Summary
- recompute dot and enforce fractional digit rules when trimming floating strings
- expand fuzz tests to 10M iterations without skipping `.0`

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bee14b252c8332aafe9158b2eccff8