### PR TITLE
Add hex-to-decimal tool using Ryu

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -15,6 +15,10 @@ FOR %%t IN (beta release) DO (
 	CALL tools\BuildCpp.cmd %%t native "%%outDir%%\MakaronCmd.exe" -I src ^
 		tools\MakaronCmd.cpp src\Makaron.cpp || GOTO error
 	SET "CPP_OPTIONS="
+	SET "CPP_OPTIONS=/std:c++14"
+	CALL tools\BuildCpp.cmd %%t native "%%outDir%%\HexDoubleToDecimal.exe" -I externals\ryu ^
+		tools\HexDoubleToDecimal.cpp externals\ryu\ryu\d2s.c || GOTO error
+	SET "CPP_OPTIONS="
 )
 ECHO Build and tests completed
 EXIT /b 0

--- a/build.sh
+++ b/build.sh
@@ -12,12 +12,15 @@ for target in beta release; do
 	CPP_OPTIONS="-std=c++11" bash tools/BuildCpp.sh "$target" native "$out_dir/doubleFloatToString" \
 		-I src tests/doubleFloatToString.cpp src/Numbstrict.cpp src/Makaron.cpp
 	"$out_dir/doubleFloatToString" > /dev/null
-       CPP_OPTIONS="-std=c++11" bash tools/BuildCpp.sh "$target" native "$out_dir/compareWithRyu" \
-               -I src -I externals/ryu tests/compareWithRyu.cpp src/Numbstrict.cpp src/Makaron.cpp \
-               externals/ryu/ryu/d2s.c externals/ryu/ryu/f2s.c
-       "$out_dir/compareWithRyu" > /dev/null
+	CPP_OPTIONS="-std=c++11" bash tools/BuildCpp.sh "$target" native "$out_dir/compareWithRyu" \
+		-I src -I externals/ryu tests/compareWithRyu.cpp src/Numbstrict.cpp src/Makaron.cpp \
+		externals/ryu/ryu/d2s.c externals/ryu/ryu/f2s.c
+	"$out_dir/compareWithRyu" > /dev/null
 	CPP_OPTIONS="-std=c++11" bash tools/BuildCpp.sh "$target" native "$out_dir/MakaronCmd" \
 		-I src tools/MakaronCmd.cpp src/Makaron.cpp
+	CPP_OPTIONS="-std=c++11" bash tools/BuildCpp.sh "$target" native "$out_dir/hexDoubleToDecimal" \
+		-I externals/ryu tools/HexDoubleToDecimal.cpp externals/ryu/ryu/d2s.c
 done
 
 echo "Build and tests completed"
+

--- a/tools/HexDoubleToDecimal.cpp
+++ b/tools/HexDoubleToDecimal.cpp
@@ -1,0 +1,76 @@
+#include "ryu/ryu.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+static std::string ryuDouble(double v) {
+	if (v == 0.0) return "0.0";
+	char buf[64];
+	int len = d2s_buffered_n(v, buf);
+	std::string s(buf, len);
+
+	bool neg = false;
+	if (!s.empty() && s[0] == '-') { neg = true; s.erase(0, 1); }
+
+	size_t ePos = s.find('E');
+	std::string mant = (ePos == std::string::npos ? s : s.substr(0, ePos));
+	int exp = 0;
+	if (ePos != std::string::npos) {
+		exp = std::stoi(s.substr(ePos + 1));
+	}
+	size_t dot = mant.find('.');
+	std::string intPart = mant.substr(0, dot);
+	std::string fracPart = (dot == std::string::npos ? "" : mant.substr(dot + 1));
+
+	const int NEG_E = -6;
+	const int POS_E = 10;
+
+	std::string result;
+	if (exp < NEG_E || exp >= POS_E) {
+		result = intPart;
+		if (!fracPart.empty()) result += '.' + fracPart; else result += ".0";
+		result += 'e';
+		result += (exp >= 0 ? '+' : '-');
+		result += std::to_string(exp >= 0 ? exp : -exp);
+	} else {
+		std::string digits = intPart + fracPart;
+		int decimalPos = static_cast<int>(intPart.size()) + exp;
+		if (decimalPos <= 0) {
+			result = "0.";
+			result.append(-decimalPos, '0');
+			result += digits;
+		} else if (decimalPos >= static_cast<int>(digits.size())) {
+			result = digits;
+			result.append(decimalPos - digits.size(), '0');
+			result += ".0";
+		} else {
+			result = digits;
+			result.insert(decimalPos, ".");
+		}
+	}
+
+	if (neg && result != "0.0") result.insert(0, "-");
+	return result;
+}
+
+int main(int argc, char** argv) {
+	if (argc != 2) {
+		std::fprintf(stderr, "Usage: %s <hex double>\n", argv[0]);
+		return 1;
+	}
+	const char* hex = argv[1];
+	if (hex[0] == '0' && (hex[1] == 'x' || hex[1] == 'X')) hex += 2;
+	char* end;
+	unsigned long long u = std::strtoull(hex, &end, 16);
+	if (!hex[0] || *end) {
+		std::fprintf(stderr, "Invalid hex value\n");
+		return 1;
+	}
+	double v;
+	std::memcpy(&v, &u, sizeof v);
+	std::string out = ryuDouble(v);
+	std::printf("%s\n", out.c_str());
+	return 0;
+}
+


### PR DESCRIPTION
## Summary
- add `HexDoubleToDecimal` tool to convert hex-encoded double values using Ryu
- build scripts compile the new utility for all targets

## Testing
- `timeout 180 bash build.sh` *(fails: double mismatch in compareWithRyu)*
- `CPP_OPTIONS="-std=c++11" bash tools/BuildCpp.sh release native output/hexDoubleToDecimal -I externals/ryu tools/HexDoubleToDecimal.cpp externals/ryu/ryu/d2s.c`
- `./output/hexDoubleToDecimal 3ff0000000000000`
- `./output/hexDoubleToDecimal 4008000000000000`


------
https://chatgpt.com/codex/tasks/task_e_68c03756969c8332b7417452d1110de2